### PR TITLE
1.5 PR bug fixes

### DIFF
--- a/src/main/java/com/raidtracker/RaidTrackerPlugin.java
+++ b/src/main/java/com/raidtracker/RaidTrackerPlugin.java
@@ -298,7 +298,7 @@ public class RaidTrackerPlugin extends Plugin
 
 	@Subscribe
 	public void onGameTick(GameTick gameTick) {
-		int WIDGET_TIMER = WidgetUtil.packComponentId(481, 46);
+
 		int WIDGET_TIMER = WidgetUtil.packComponentId(TOA_CANVAS_WIDGET_ID, TOA_TIMER_WIDGET_ID);
 		if (raidTracker.isInTombsOfAmascut() && client.getWidget(WIDGET_TIMER) != null) {
 			if (!Objects.equals(Objects.requireNonNull(client.getWidget(WIDGET_TIMER)).getText(), "00:00")

--- a/src/test/java/com/raidtracker/RaidTrackerTest.java
+++ b/src/test/java/com/raidtracker/RaidTrackerTest.java
@@ -13,6 +13,7 @@ import net.runelite.api.Player;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.http.api.item.ItemPrice;
 import org.junit.Before;
@@ -55,14 +56,15 @@ public class RaidTrackerTest extends TestCase
     @Bind
     private RaidTrackerConfig raidTrackerConfig;
 
+    @Mock
+    @Bind
+    private PluginManager pluginManager;
 
     @Inject
     private RaidTrackerPlugin raidTrackerPlugin;
 
-
     @Before
-    public void setUp()
-    {
+    public void setUp() {
         Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
     }
 

--- a/src/test/java/com/raidtracker/RaidTrackerTest.java
+++ b/src/test/java/com/raidtracker/RaidTrackerTest.java
@@ -35,6 +35,36 @@ import static org.mockito.Mockito.when;
 public class RaidTrackerTest extends TestCase
 {
 
+    @Mock
+    @Bind
+    private Client client;
+
+    @Mock
+    @Bind
+    private ConfigManager configManager;
+
+    @Mock
+    @Bind
+    private ItemManager itemManager;
+
+    @Mock
+    @Bind
+    private ClientToolbar clientToolbar;
+
+    @Mock
+    @Bind
+    private RaidTrackerConfig raidTrackerConfig;
+
+
+    @Inject
+    private RaidTrackerPlugin raidTrackerPlugin;
+
+
+    @Before
+    public void setUp()
+    {
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
 
 	@Test
 	public void TestLootSplits() {
@@ -109,37 +139,6 @@ public class RaidTrackerTest extends TestCase
 		raidTrackerPlugin.setSplits(raidTracker);
 
 		assertEquals(-1 , raidTracker.getLootSplitReceived());
-	}
-
-	@Mock
-	@Bind
-	private Client client;
-
-	@Mock
-	@Bind
-	private ConfigManager configManager;
-
-	@Mock
-	@Bind
-	private ItemManager itemManager;
-
-	@Mock
-	@Bind
-	private ClientToolbar clientToolbar;
-
-	@Mock
-	@Bind
-	private RaidTrackerConfig raidTrackerConfig;
-
-
-	@Inject
-	private RaidTrackerPlugin raidTrackerPlugin;
-
-
-	@Before
-	public void setUp()
-	{
-		Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
 	}
 
 	//---------------------------------- onChatMessage tests ------------------------------------------------

--- a/src/test/java/com/raidtracker/RaidTrackerTest.java
+++ b/src/test/java/com/raidtracker/RaidTrackerTest.java
@@ -131,7 +131,7 @@ public class RaidTrackerTest extends TestCase
 		raidTrackerPlugin.setSplits(raidTracker);
 
 		assertTrue(raidTracker.isFreeForAll());
-		assertEquals(raidTracker.getLootSplitReceived(), 2000000);
+		assertEquals(2000000, raidTracker.getLootSplitReceived());
 		assertEquals(-1, raidTracker.getLootSplitPaid());
 
 		raidTracker.setSpecialLootReceiver("K1NG DK");

--- a/src/test/java/com/raidtracker/RaidTrackerTest.java
+++ b/src/test/java/com/raidtracker/RaidTrackerTest.java
@@ -140,7 +140,7 @@ public class RaidTrackerTest extends TestCase
 		raidTracker.setLootSplitReceived(-1);
 		raidTrackerPlugin.setSplits(raidTracker);
 
-		assertEquals(-1 , raidTracker.getLootSplitReceived());
+		assertEquals(-1, raidTracker.getLootSplitReceived());
 	}
 
 	//---------------------------------- onChatMessage tests ------------------------------------------------


### PR DESCRIPTION
Fixes two critical bugs that popped up during my original 1.5 PR and 1 minor bug.

- Removes duplicate WIDGET_TIMER variable in RaidTrackerPlugin
- Adds a dependence (PluginManager) to tests that would otherwise cause tests to fail in RaidTrackerTest
- Fixes the order of one of the assertEquals statements in RaidTrackerTest
- Minor formatting changes