### PR TITLE
Fix split gp over 2.14b

### DIFF
--- a/src/main/java/com/raidtracker/ui/RaidTrackerPanel.java
+++ b/src/main/java/com/raidtracker/ui/RaidTrackerPanel.java
@@ -751,12 +751,10 @@ public class RaidTrackerPanel extends PluginPanel {
         wrapper.setBorder(new EmptyBorder(3, 3, 3, 3));
         wrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR.darker());
 
-        int splitGP = 0;
+        long splitGP = 0;
 
         if (loaded) {
-            splitGP = atLeastZero(getFilteredRTList().stream().mapToInt(RaidTracker::getLootSplitReceived).sum());
-
-
+            splitGP = atLeastZero(getFilteredRTList().stream().mapToLong(RaidTracker::getLootSplitReceived).sum());
         }
 
         JLabel textLabel = textPanel("Split GP earned:");
@@ -1993,6 +1991,10 @@ public class RaidTrackerPanel extends PluginPanel {
     }
 
     public int atLeastZero(int maybeLessThanZero) {
+        return Math.max(maybeLessThanZero, 0);
+    }
+
+    public long atLeastZero(long maybeLessThanZero) {
         return Math.max(maybeLessThanZero, 0);
     }
 


### PR DESCRIPTION
Since the plugin has been down, I've tracked my splits manually and imported them all this morning. I was lucky enough that this pushed me over the maximum integer value, but the split value only showed "0" - changing this to `long` fixes the issue

before:
![2025-03-29_10-31](https://github.com/user-attachments/assets/b5eb986a-03b6-4058-a7f1-8fe0fac9fd55)

after:
![2025-03-29_10-30](https://github.com/user-attachments/assets/da2a594b-f63a-4e3c-a185-94a92b278299)
