### PR TITLE
Add Discord webhook integration for raid completions

### DIFF
--- a/src/main/java/com/raidtracker/RaidTrackerConfig.java
+++ b/src/main/java/com/raidtracker/RaidTrackerConfig.java
@@ -3,6 +3,7 @@ package com.raidtracker;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup(RaidTrackerConfig.CONFIG_GROUP)
 public interface RaidTrackerConfig extends Config
@@ -153,4 +154,34 @@ public interface RaidTrackerConfig extends Config
 		hidden = true
 	)
 	default int toaFilterCustomHigh() { return 600; }
+
+	@ConfigSection(
+			name = "Discord Webhook",
+			description = "Settings for posting raid completions to a Discord webhook",
+			position = 99
+	)
+	String discordSection = "discord";
+
+	@ConfigItem(
+			keyName = "webhookEnabled",
+			name = "Send to Discord",
+			description = "Automatically send raid data to a Discord webhook upon completion.",
+			position = 100,
+			section = discordSection
+	)
+	default boolean webhookEnabled() {
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "webhookUrl",
+			name = "Webhook URL",
+			description = "The Discord webhook URL to send the raid data to.",
+			position = 101,
+			section = discordSection
+	)
+	default String webhookUrl() {
+		return "";
+	}
+
 }

--- a/src/main/java/com/raidtracker/RaidTrackerPlugin.java
+++ b/src/main/java/com/raidtracker/RaidTrackerPlugin.java
@@ -8,6 +8,8 @@ import com.raidtracker.ui.RaidTrackerPanel;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.raidtracker.webhook.DiscordWebhook;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
@@ -56,6 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.lang.Integer.parseInt;
 import static java.lang.Float.parseFloat;
 import net.runelite.http.api.item.ItemPrice;
+import okhttp3.OkHttpClient;
 
 @Slf4j
 @PluginDescriptor(
@@ -123,6 +126,11 @@ public class RaidTrackerPlugin extends Plugin
 	@Inject
 	private PluginManager pluginManager;
 
+	@Inject
+	private OkHttpClient okHttpClient;
+
+	private DiscordWebhook discordWebhook;
+
     private boolean isFirstGameTick = true;
 
 	@Provides
@@ -162,6 +170,7 @@ public class RaidTrackerPlugin extends Plugin
 			fw.updateUsername(client.getUsername());
 			SwingUtilities.invokeLater(() -> panel.loadRTList());
 		}
+		this.discordWebhook = new DiscordWebhook(okHttpClient);
 	}
 
 	@Override
@@ -381,6 +390,8 @@ public class RaidTrackerPlugin extends Plugin
 
                 fw.writeToFile(raidTracker);
 
+				sendToWebhookIfEnabled(raidTracker);
+
                 SwingUtilities.invokeLater(() -> {
                     panel.addDrop(raidTracker);
                     reset();
@@ -421,6 +432,8 @@ public class RaidTrackerPlugin extends Plugin
                 } else {
                     fw.writeToFile(raidTracker);
                 }
+
+				sendToWebhookIfEnabled(raidTracker);
 
                 SwingUtilities.invokeLater(() -> {
                     panel.addDropToPanel(raidTracker);
@@ -490,6 +503,8 @@ public class RaidTrackerPlugin extends Plugin
                 raidTracker.setLootList(lootListFactory(rewardItemContainer.getItems()));
 
                 fw.writeToFile(raidTracker);
+
+				sendToWebhookIfEnabled(raidTracker);
 
                 writerStarted = true;
 
@@ -764,6 +779,8 @@ public class RaidTrackerPlugin extends Plugin
 					setSplits(altRT);
 
 					fw.writeToFile(altRT);
+
+					sendToWebhookIfEnabled(altRT);
 
 					SwingUtilities.invokeLater(() -> panel.addDrop(altRT, false));
 				} else {
@@ -1057,4 +1074,20 @@ public class RaidTrackerPlugin extends Plugin
 		});
 	}
 
+	private void sendToWebhookIfEnabled(final RaidTracker completedRaid) {
+		// First, a sanity check to ensure the raid is actually marked complete.
+		if (!completedRaid.isRaidComplete()) {
+			log.debug("Webhook send skipped: raid not marked as complete.");
+			return;
+		}
+
+		// Now, check the user's config settings.
+		if (config.webhookEnabled() && !config.webhookUrl().isEmpty()) {
+			log.debug("Raid complete, sending to Discord webhook.");
+
+			// This is the call to our DiscordWebhook class.
+			// It uses the EXACT object that was just saved to the file.
+			discordWebhook.sendRaid(completedRaid, config.webhookUrl());
+		}
+	}
 }

--- a/src/main/java/com/raidtracker/webhook/DiscordWebhook.java
+++ b/src/main/java/com/raidtracker/webhook/DiscordWebhook.java
@@ -1,0 +1,248 @@
+package com.raidtracker.webhook;
+
+import com.raidtracker.RaidTracker;
+import com.raidtracker.RaidTrackerItem;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.text.NumberFormat;
+import java.util.Locale;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public class DiscordWebhook {
+
+    private final OkHttpClient httpClient;
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getNumberInstance(Locale.US);
+
+    public DiscordWebhook(OkHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Sends the raid data to the specified webhook URL.
+     * @param raidTracker The fully populated raid data object.
+     * @param webhookUrl The Discord webhook URL.
+     */
+    public void sendRaid(final RaidTracker raidTracker, final String webhookUrl) {
+        if (webhookUrl == null || webhookUrl.isEmpty()) {
+            return;
+        }
+
+        String jsonPayload = buildJsonPayload(raidTracker);
+
+        RequestBody body = RequestBody.create(JSON, jsonPayload);
+        Request request = new Request.Builder()
+                .url(webhookUrl)
+                .post(body)
+                .build();
+
+        httpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                log.error("Failed to send raid data to Discord webhook", e);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                if (!response.isSuccessful()) {
+                    log.error("Failed to send raid data to Discord. Server responded with: {} {}", response.code(), response.body() != null ? response.body().string() : "No Body");
+                }
+                response.close();
+            }
+        });
+    }
+
+    private String buildJsonPayload(RaidTracker rt) {
+        // Main embed structure
+        StringBuilder embed = new StringBuilder();
+        embed.append("{");
+
+        String description = "Raid Completion Data";
+        embed.append("\"content\": null,");
+        embed.append("\"embeds\": [{");
+        embed.append("\"description\": \"").append(description).append("\",");
+
+        // Determine raid type and set title/color accordingly
+        if (rt.isInRaidChambers()) {
+            embed.append("\"title\": \"Chambers of Xeric").append("\",");
+            embed.append("\"color\": 4995442,"); // CoX Brown
+            buildCoxFields(embed, rt);
+        } else if (rt.isInTheatreOfBlood()) {
+            embed.append("\"title\": \"Theatre of Blood").append("\",");
+            embed.append("\"color\": 9320960,"); // ToB Red
+            buildTobFields(embed, rt);
+        } else if (rt.isInTombsOfAmascut()) {
+            embed.append("\"title\": \"Tombs of Amascut").append("\",");
+            embed.append("\"color\": 14594626,"); // ToA Gold
+            buildToaFields(embed, rt);
+        } else {
+            embed.append("\"title\": \"Raid Completion").append("\",");
+            embed.append("\"color\": 10181046,"); // Grey
+            buildCommonFields(embed, rt); // Fallback to common fields if raid type is unknown
+        }
+
+        // Add footer with timestamp
+        embed.append("\"footer\": {\"text\": \"Raid Data Tracker\"},");
+        embed.append("\"timestamp\": \"").append(new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(new java.util.Date(rt.getDate()))).append("\"");
+
+        embed.append("}]}");
+        return embed.toString();
+    }
+
+    // Helper to build the "fields" array for the embed
+    private void appendFields(StringBuilder embed, List<String> fields) {
+        embed.append("\"fields\": [").append(String.join(",", fields)).append("],");
+    }
+
+    // Builder for Common Fields (used by all raid types)
+    private void buildCommonFields(StringBuilder embed, RaidTracker rt) {
+        List<String> fields = new ArrayList<>();
+
+        // General Info
+        fields.add(createField("Team Size", String.valueOf(rt.getTeamSize()), true));
+        if (rt.isChallengeMode()) {
+            fields.add(createField("Mode", "Challenge Mode", true));
+        }
+        fields.add(createField("Total Points", formatNumber(rt.getTotalPoints()), true));
+        fields.add(createField("Personal Points", formatNumber(rt.getPersonalPoints()), true));
+        fields.add(createField("Completion Time", secondsToMinuteString(rt.getRaidTime()), true));
+
+        // Loot Section
+        buildLootFields(fields, rt);
+
+        appendFields(embed, fields);
+    }
+
+    // Specific builder for CoX
+    private void buildCoxFields(StringBuilder embed, RaidTracker rt) {
+        List<String> fields = new ArrayList<>();
+
+        fields.add(createField("Team Size", String.valueOf(rt.getTeamSize()), true));
+        if (rt.isChallengeMode()) {
+            fields.add(createField("Mode", "Challenge Mode", true));
+        } else {
+            fields.add(createField("Mode", "Normal", true));
+        }
+        fields.add(createField("Total Points", formatNumber(rt.getTotalPoints()), true));
+        fields.add(createField("Personal Points", formatNumber(rt.getPersonalPoints()), true));
+        fields.add(createField("Your Deaths", String.valueOf(rt.getPersonalDeathCount()), true));
+
+        // Times
+        fields.add(createField("Raid Time", secondsToMinuteString(rt.getRaidTime()), false));
+        fields.add(createField("Olm Phase", secondsToMinuteString(rt.getRaidTime() - rt.getLowerTime()), true));
+        fields.add(createField("Lower Level", secondsToMinuteString(rt.getLowerTime() - rt.getMiddleTime()), true));
+        fields.add(createField("Upper Level", secondsToMinuteString(rt.getUpperTime()), true));
+
+        // Loot Section
+        buildLootFields(fields, rt);
+
+        appendFields(embed, fields);
+    }
+
+    // Specific builder for ToB
+    private void buildTobFields(StringBuilder embed, RaidTracker rt) {
+        List<String> fields = new ArrayList<>();
+
+        fields.add(createField("Team Size", String.valueOf(rt.getTeamSize()), true));
+        if (rt.isChallengeMode()) {
+            fields.add(createField("Mode", "Hard Mode", true));
+        } else {
+            fields.add(createField("Mode", "Normal", true));
+        }
+        fields.add(createField("MVP", rt.getMvp().isEmpty() ? "N/A" : rt.getMvp(), true));
+        fields.add(createField("Completion Time", secondsToMinuteString(rt.getTobCompTime()), false));
+
+        // Deaths
+        fields.add(createField("Your Deaths", String.valueOf(rt.getPersonalDeathCount()), true));
+        fields.add(createField("Team Deaths", String.valueOf(rt.getTotalTeamDeathCount()), true));
+
+        // Loot Section
+        buildLootFields(fields, rt);
+
+        appendFields(embed, fields);
+    }
+
+    // Specific builder for ToA
+    private void buildToaFields(StringBuilder embed, RaidTracker rt) {
+        List<String> fields = new ArrayList<>();
+
+        fields.add(createField("Team Size", String.valueOf(rt.getTeamSize()), true));
+        fields.add(createField("Raid Level", String.valueOf(rt.getRaidLevel()), true));
+        fields.add(createField("Total Points", formatNumber(rt.getTotalPoints()), true));
+        fields.add(createField("Completion Time", secondsToMinuteString(rt.getToaCompTime()), false));
+
+        // Deaths
+        fields.add(createField("Your Deaths", String.valueOf(rt.getPersonalDeathCount()), true));
+        fields.add(createField("Team Deaths", String.valueOf(rt.getTotalTeamDeathCount()), true));
+
+        // Path Times
+        fields.add(createField("Path of Apmeken", secondsToMinuteString(rt.getApmekenTime() + rt.getBabaTime()), true));
+        fields.add(createField("Path of Scabaras", secondsToMinuteString(rt.getScabarasTime() + rt.getKephriTime()), true));
+        fields.add(createField("Path of Het", secondsToMinuteString(rt.getHetTime() + rt.getAkkhaTime()), true));
+        fields.add(createField("Path of Crondis", secondsToMinuteString(rt.getCrondisTime() + rt.getZebakTime()), true));
+        fields.add(createField("Wardens", secondsToMinuteString(rt.getWardensTime()), true));
+
+        // Loot Section
+        buildLootFields(fields, rt);
+
+        appendFields(embed, fields);
+    }
+
+    // Helper to build the loot-related fields, which are common to all raids
+    private void buildLootFields(List<String> fields, RaidTracker rt) {
+        if (!rt.getSpecialLoot().isEmpty()) {
+            String specialLootText = rt.isSpecialLootInOwnName() ?
+                    "**" + rt.getSpecialLoot() + "** (In your name!)" :
+                    rt.getSpecialLoot() + " (Received by: " + rt.getSpecialLootReceiver() + ")";
+            fields.add(createField("💜 Special Loot", specialLootText, false));
+        }
+
+        StringBuilder lootString = new StringBuilder();
+        long totalLootValue = 0;
+        if (rt.getLootList() != null && !rt.getLootList().isEmpty()) {
+            for (RaidTrackerItem item : rt.getLootList()) {
+                long value = item.getPrice();
+                totalLootValue += value;
+                lootString.append("`").append(item.getQuantity()).append("x` ")
+                        .append(item.getName())
+                        .append(" *(").append(formatNumber(value)).append(" gp)*\n");
+            }
+        }
+
+        if (lootString.length() == 0) {
+            lootString.append("No notable loot.");
+        }
+
+        fields.add(createField("💰 Loot Chest (Value: " + formatNumber(totalLootValue) + " gp)", lootString.toString(), false));
+    }
+
+
+    // Creates a JSON object for a field
+    private String createField(String name, String value, boolean inline) {
+        // Escape quotes in name and value to prevent breaking the JSON
+        String safeName = name.replace("\"", "\\\"");
+        String safeValue = value.replace("\"", "\\\"").replace("\n", "\\n");
+        return String.format("{\"name\": \"%s\", \"value\": \"%s\", \"inline\": %b}", safeName, safeValue, inline);
+    }
+
+    private String formatNumber(long number) {
+        if (number < 0) return "N/A";
+        return NUMBER_FORMAT.format(number);
+    }
+
+    private String secondsToMinuteString(int seconds) {
+        if (seconds <= 0) {
+            return "N/A";
+        }
+        return seconds / 60 + ":" + String.format("%02d", seconds % 60);
+    }
+}


### PR DESCRIPTION
This allows for easy sharing of raid logs with clan members or for personal tracking in a dedicated Discord channel, without needing to manually screenshot or type out results. Also allows for any backend service to track this data. This allows us to track points from raids for events for accurate metrics.

Additions:
A new "Discord Webhook" section has been added to the plugin's configuration.
Users can enable the feature with a "Send to Discord" checkbox and paste their webhook URL into a new field.
Upon completing a raid (when the loot chest is opened), the plugin now constructs and sends a rich Discord embed of the raidTracker obj to the provided URL.